### PR TITLE
Malaca fix doc

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -39,6 +39,11 @@ const myCircuit = new Mollitia.Circuit({
     }
   }
 });
+
+// ...
+
+const myCircuitMetrics = myCircuit.prometheus.metrics; // Will return an object containing all metrics from this circuit
+const myCircuitScrap = myCircuit.prometheus.scrap(); // Will return the Prometheus scrap from this circuit
 ```
 
 Finally, you can get `Prometheus` metrics or scrap like this:

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -24,11 +24,9 @@ Then, add `Prometheus` options when creating circuits or modules:
 
 ``` javascript
 const myModule = new Mollitia.Timeout({
-  options: {
     prometheus: {
       name: 'my-module'
     }
-  }
 });
 const myCircuit = new Mollitia.Circuit({
   options: {


### PR DESCRIPTION
I did an little change on example.

I fixed the example from create of timeout module. There isn't the object "options" to create timeout module.

Also I added an example to return metrics and scrap from an circuit.


